### PR TITLE
minishell_testerの対応終了

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,32 +1,31 @@
-
-EXEC_DIR := srcs/exec
-EXEC_FILES := dup_stdin.c dup_stdout.c exec_cmd_list.c exec_test.c exec_cmd.c find_cmd_path.c \
-forked_process_helper.c heredoc.c set_tmp_file.c set_pipe_fork.c store_stdio.c utils.c
-EXEC_SRCS := $(addprefix $(EXEC_DIR)/, $(EXEC_FILES))
-
 BUILTIN_DIR := srcs/builtin
 BUILTIN_FILES := pwd.c cd.c echo.c exit.c env.c export.c unset.c test.c
 BUILTIN_SRCS := $(addprefix $(BUILTIN_DIR)/, $(BUILTIN_FILES))
-
-UTILS_DIR := srcs/utils
-UTILS_FILES := envp.c free.c free2.c list.c malloc.c t_env.c 
-UTILS_SRCS := $(addprefix $(UTILS_DIR)/, $(UTILS_FILES))
-
-LEXER_DIR := srcs/lexer
-LEXER_FILES := lexer.c lexer_utils.c token_processing.c quote_process.c validate_token.c validate_token2.c
-LEXER_SRCS := $(addprefix $(LEXER_DIR)/, $(LEXER_FILES))
 
 DEBUG_DIR := srcs/debug
 DEBUG_FILES := print_tokens.c print.c
 DEBUG_SRCS := $(addprefix $(DEBUG_DIR)/, $(DEBUG_FILES))
 
+EXEC_DIR := srcs/exec
+EXEC_FILES := dup_stdin.c dup_stdout.c exec_cmd_list.c exec_test.c exec_cmd.c find_cmd_path.c find_cmd_path_errmsg.c \
+forked_process_helper.c heredoc_signal.c heredoc.c set_tmp_file.c set_pipe_fork.c store_stdio.c utils.c
+EXEC_SRCS := $(addprefix $(EXEC_DIR)/, $(EXEC_FILES))
+
+EXPANDER_DIR := srcs/expander
+EXPANDER_FILES := expander.c replace_env.c replace.c
+EXPANDER_SRCS := $(addprefix $(EXPANDER_DIR)/, $(EXPANDER_FILES))
+
+LEXER_DIR := srcs/lexer
+LEXER_FILES := lexer.c lexer_utils.c token_processing.c quote_process.c validate_token.c validate_token2.c
+LEXER_SRCS := $(addprefix $(LEXER_DIR)/, $(LEXER_FILES))
+
 PARSER_DIR := srcs/parser
 PARSER_FILES := parser.c parser_utils.c
 PARSER_SRCS := $(addprefix $(PARSER_DIR)/, $(PARSER_FILES))
 
-EXPANDER_DIR := srcs/expander
-EXPANDER_FILES := expander.c replace_env.c
-EXPANDER_SRCS := $(addprefix $(EXPANDER_DIR)/, $(EXPANDER_FILES))
+UTILS_DIR := srcs/utils
+UTILS_FILES := envp.c free.c free2.c list.c malloc.c t_env.c path_validator.c
+UTILS_SRCS := $(addprefix $(UTILS_DIR)/, $(UTILS_FILES))
 
 CC		:= cc
 CFLAGS	:= -Wall -Wextra -Werror

--- a/includes/exec.h
+++ b/includes/exec.h
@@ -6,7 +6,7 @@
 /*   By: hnagasak <hnagasak@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/31 16:07:35 by hnagasak          #+#    #+#             */
-/*   Updated: 2024/03/28 20:58:32 by hnagasak         ###   ########.fr       */
+/*   Updated: 2024/03/28 21:37:57 by hnagasak         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,7 +19,7 @@
 # include "utils.h"
 # include <fcntl.h>
 
-int					g_signum;
+extern int			g_signum;
 
 typedef enum e_redir_type
 {

--- a/includes/exec.h
+++ b/includes/exec.h
@@ -6,7 +6,7 @@
 /*   By: hnagasak <hnagasak@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/31 16:07:35 by hnagasak          #+#    #+#             */
-/*   Updated: 2024/03/22 10:54:28 by hnagasak         ###   ########.fr       */
+/*   Updated: 2024/03/26 22:56:45 by hnagasak         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,6 +18,8 @@
 # include "libft.h"
 # include "utils.h"
 # include <fcntl.h>
+
+int		g_signum;
 
 typedef enum e_redir_type
 {
@@ -47,7 +49,7 @@ typedef struct s_cmd
 }					t_cmd;
 
 // dup_stdin.c
-void				dup_stdin(t_dlist *current);
+int					dup_stdin(t_dlist *current);
 int					get_dupin_fd(t_cmd *cmd);
 void				pipout2stdin(t_dlist *cmdlst);
 // dup_stdout.c
@@ -82,8 +84,9 @@ int					wait_children(t_dlist **cmd_list);
 void				input_heredocs(t_cmd *cmd, t_dlist **env_list);
 int					get_delimiter_type(char *delimiter);
 char				*expand_heredoc(char *str, t_dlist **env_list);
-void				input_hd(t_cmd *cmd, t_redir *redir, int fd,
-						t_dlist **env_list);
+// void				input_hd(t_cmd *cmd, t_redir *redir, int fd,
+// 						t_dlist **env_list);
+void				input_hd(t_cmd *cmd, t_redir *redir, t_dlist **env_list);
 void				ft_heredoc(t_cmd *cmd, t_redir *redir, t_dlist **env_list);
 // set_pipe_fork.c
 void				set_pipe_if_needed(t_dlist *current);

--- a/includes/exec.h
+++ b/includes/exec.h
@@ -6,7 +6,7 @@
 /*   By: hnagasak <hnagasak@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/31 16:07:35 by hnagasak          #+#    #+#             */
-/*   Updated: 2024/03/27 01:44:00 by hnagasak         ###   ########.fr       */
+/*   Updated: 2024/03/28 20:58:32 by hnagasak         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -70,16 +70,29 @@ int					exec_external_or_piped_cmd(t_dlist **cmd_list,
 // exec_test.c
 void				print_arr_str(char **arr_str);
 void				print_cmd_list(t_dlist **cmd_list);
+
 // find_cmd_path.c
 char				**get_paths(t_dlist **env_list);
 char				*cat_path(char *path, char *cmd);
-// char				*find_cmd_path(char *paths[], char *cmd);
 int					find_cmd_path(char **cmd_path, char *paths[], char *cmd);
+
+// find_cmd_path_errmsg.c
+int					errmsg_isdir(char *cmd);
+int					errmsg_missing_path(char *cmd);
+int					errmsg_permission(char *cmd);
+int					errmsg_cmd_not_found(char *cmd);
+
 // forked_process_manage.c
 void				child_process(t_dlist *current, t_dlist **env_list);
 void				close_parent_pipe(t_dlist *current);
 void				fail_fork(void);
 int					wait_children(t_dlist **cmd_list);
+
+// heredoc_signal.c
+void				sig_hd(int signum);
+int					eof_handler(void);
+int					should_break(char *line, t_redir *redir, int *fd);
+
 // heredoc.c
 void				input_heredocs(t_cmd *cmd, t_dlist **env_list);
 int					get_delimiter_type(char *delimiter);

--- a/includes/exec.h
+++ b/includes/exec.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   exec.h                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: hnagasak <hnagasak@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*   By: hnagasak <hnagasak@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/31 16:07:35 by hnagasak          #+#    #+#             */
-/*   Updated: 2024/03/28 21:37:57 by hnagasak         ###   ########.fr       */
+/*   Updated: 2024/03/30 10:48:28 by hnagasak         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -64,9 +64,10 @@ int					exec_externalcmd(t_cmd *cmd, t_dlist **env_list);
 // exec_cmd_list.c
 void				exec_cmd_list(t_dlist **cmd_list, t_dlist **env_list,
 						int *exit_status);
-int					exec_single_builtin(t_dlist *current, t_dlist **env_list);
+int					exec_single_builtin(t_dlist *current, t_dlist **env_list,
+						int exit_status);
 int					exec_external_or_piped_cmd(t_dlist **cmd_list,
-						t_dlist **env_list);
+						t_dlist **env_list, int exit_status);
 // exec_test.c
 void				print_arr_str(char **arr_str);
 void				print_cmd_list(t_dlist **cmd_list);
@@ -94,13 +95,15 @@ int					eof_handler(void);
 int					should_break(char *line, t_redir *redir, int *fd);
 
 // heredoc.c
-void				input_heredocs(t_cmd *cmd, t_dlist **env_list);
+void				input_heredocs(t_cmd *cmd, t_dlist **env_list,
+						int exit_status);
 int					get_delimiter_type(char *delimiter);
-char				*expand_heredoc(char *str, t_dlist **env_list);
-// void				input_hd(t_cmd *cmd, t_redir *redir, int fd,
-// 						t_dlist **env_list);
-void				input_hd(t_cmd *cmd, t_redir *redir, t_dlist **env_list);
-void				ft_heredoc(t_cmd *cmd, t_redir *redir, t_dlist **env_list);
+char				*expand_heredoc(char *str, t_dlist **env_list,
+						int replace_exit_status);
+void				input_hd(t_cmd *cmd, t_redir *redir, t_dlist **env_list,
+						int exit_status);
+void				ft_heredoc(t_cmd *cmd, t_redir *redir, t_dlist **env_list,
+						int exit_status);
 // set_pipe_fork.c
 void				set_pipe_if_needed(t_dlist *current);
 void				set_fork(t_dlist *current);

--- a/includes/exec.h
+++ b/includes/exec.h
@@ -6,7 +6,7 @@
 /*   By: hnagasak <hnagasak@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/31 16:07:35 by hnagasak          #+#    #+#             */
-/*   Updated: 2024/03/26 22:56:45 by hnagasak         ###   ########.fr       */
+/*   Updated: 2024/03/27 01:44:00 by hnagasak         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -53,7 +53,7 @@ int					dup_stdin(t_dlist *current);
 int					get_dupin_fd(t_cmd *cmd);
 void				pipout2stdin(t_dlist *cmdlst);
 // dup_stdout.c
-void				dup_stdout(t_dlist *current);
+int					dup_stdout(t_dlist *current);
 int					get_dupout_fd(t_cmd *cmd);
 void				pipin2stdout(t_dlist *cmdlst);
 // exec_cmd.c

--- a/includes/exec.h
+++ b/includes/exec.h
@@ -19,7 +19,7 @@
 # include "utils.h"
 # include <fcntl.h>
 
-int		g_signum;
+int					g_signum;
 
 typedef enum e_redir_type
 {

--- a/includes/expander.h
+++ b/includes/expander.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   expander.h                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: hnagasak <hnagasak@student.42.fr>          +#+  +:+       +#+        */
+/*   By: hnagasak <hnagasak@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/01/27 15:27:37 by kogitsu           #+#    #+#             */
-/*   Updated: 2024/03/17 18:33:24 by hnagasak         ###   ########.fr       */
+/*   Updated: 2024/03/28 08:55:00 by hnagasak         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,14 +24,15 @@ typedef enum e_expandable_state
 	IN_DQUOTE
 }		t_expandable_state;
 
+// expander.c
 t_token	*expand_env(t_token *tokens, t_dlist **env_list, int exit_status);
-void	replace_env_value(char **str_head, char **start, char *env_value);
 
 // replace_env.c
 char	*find_env_value(char *char_position, t_dlist *env_list);
-void	copy_str_func(char **new_str, char **src, char end);
-void	replace_env_value(char **str_head, char **start, char *env_value);
-size_t	toggle_quote_state(size_t state, char *str);
 char	*replace_env_var(char *str, t_dlist **env_list, int exit_status);
+
+// replace.c
+void	replace_env_value(char **str_head, char **start, char *env_value);
+void	replace_exit_status(char **str_head, char **start, int exit_status);
 
 #endif

--- a/includes/utils.h
+++ b/includes/utils.h
@@ -6,7 +6,7 @@
 /*   By: hnagasak <hnagasak@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/21 12:45:23 by hnagasak          #+#    #+#             */
-/*   Updated: 2024/03/20 22:09:29 by hnagasak         ###   ########.fr       */
+/*   Updated: 2024/03/25 20:09:31 by hnagasak         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -40,9 +40,9 @@ size_t				get_argc(char *argv[]);
 int					is_env_key_char(char c);
 char				**envlist2arr(t_dlist **env_list);
 
-int is_executable_file(char *path);
-int	is_directory(const char *path);
-int is_updatable_file(char *path);
+int					is_executable_file(char *path);
+int					is_directory(const char *path);
+int					is_updatable_file(char *path);
 
 // list.c
 t_dlist				*ft_dlstnew(void *content);

--- a/includes/utils.h
+++ b/includes/utils.h
@@ -6,7 +6,7 @@
 /*   By: hnagasak <hnagasak@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/21 12:45:23 by hnagasak          #+#    #+#             */
-/*   Updated: 2024/03/25 20:09:31 by hnagasak         ###   ########.fr       */
+/*   Updated: 2024/03/28 21:03:48 by hnagasak         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -40,9 +40,8 @@ size_t				get_argc(char *argv[]);
 int					is_env_key_char(char c);
 char				**envlist2arr(t_dlist **env_list);
 
-int					is_executable_file(char *path);
+// path_validator.c
 int					is_directory(const char *path);
-int					is_updatable_file(char *path);
 
 // list.c
 t_dlist				*ft_dlstnew(void *content);

--- a/srcs/builtin/echo.c
+++ b/srcs/builtin/echo.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   echo.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: hnagasak <hnagasak@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*   By: hnagasak <hnagasak@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/05 14:08:27 by hnagasak          #+#    #+#             */
-/*   Updated: 2024/03/02 19:00:32 by hnagasak         ###   ########.fr       */
+/*   Updated: 2024/03/27 21:24:24 by hnagasak         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,13 +24,12 @@ void	ft_echo(char *argv[])
 		return ;
 	}
 	opt = 0;
-	if (ft_strncmp("-n", argv[1], 2) == 0)
+	i = 1;
+	while (ft_strncmp("-n", argv[i], 3) == 0)
 	{
-		i = 2;
+		i++;
 		opt |= ECHO_OPT_N;
 	}
-	else
-		i = 1;
 	while (argv[i] != NULL)
 	{
 		printf("%s", argv[i]);

--- a/srcs/builtin/exit.c
+++ b/srcs/builtin/exit.c
@@ -6,7 +6,7 @@
 /*   By: hnagasak <hnagasak@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/19 18:23:23 by hnagasak          #+#    #+#             */
-/*   Updated: 2024/03/22 10:58:37 by hnagasak         ###   ########.fr       */
+/*   Updated: 2024/03/28 08:36:40 by hnagasak         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -41,7 +41,6 @@ int	ft_exit(char *argv[])
 {
 	int	exit_status;
 
-	// ft_errmsg("exit\n");
 	printf("exit\n");
 	exit_status = is_invalid_arg(argv);
 	if (exit_status != 0)

--- a/srcs/debug/print.c
+++ b/srcs/debug/print.c
@@ -6,7 +6,7 @@
 /*   By: hnagasak <hnagasak@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/01/04 17:27:01 by hnagasak          #+#    #+#             */
-/*   Updated: 2024/03/11 10:11:29 by hnagasak         ###   ########.fr       */
+/*   Updated: 2024/03/28 21:05:18 by hnagasak         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -46,19 +46,19 @@ void	print_envlist(t_dlist **env_list)
 	printf("--- end print_env ----\n");
 }
 
-void	ft_debug(const char *format, ...)
-{
-	va_list	args;
-
-	if (DEBUG)
-	{
-		va_start(args, format);
-		vfprintf(stderr, format, args);
-		va_end(args);
-	}
-}
-
 // void	ft_debug(const char *format, ...)
 // {
-// 	(void)format;
+// 	va_list	args;
+
+// 	if (DEBUG)
+// 	{
+// 		va_start(args, format);
+// 		vfprintf(stderr, format, args);
+// 		va_end(args);
+// 	}
 // }
+
+void	ft_debug(const char *format, ...)
+{
+	(void)format;
+}

--- a/srcs/exec/dup_stdin.c
+++ b/srcs/exec/dup_stdin.c
@@ -6,7 +6,7 @@
 /*   By: hnagasak <hnagasak@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/07 01:43:16 by hnagasak          #+#    #+#             */
-/*   Updated: 2024/03/27 01:42:31 by hnagasak         ###   ########.fr       */
+/*   Updated: 2024/03/28 09:38:14 by hnagasak         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,8 +26,7 @@ int	dup_stdin(t_dlist *current)
 		fd = get_dupin_fd(cmd);
 		if (fd == -1)
 			return (EXIT_FAILURE);
-		dup2(fd,STDIN_FILENO);
-		// dup2(get_dupin_fd(cmd), STDIN_FILENO);
+		dup2(fd, STDIN_FILENO);
 	}
 	else if (current->prv != NULL && cmd->input == NULL)
 		pipout2stdin(current->prv);
@@ -36,8 +35,7 @@ int	dup_stdin(t_dlist *current)
 		fd = get_dupin_fd(cmd);
 		if (fd == -1)
 			return (EXIT_FAILURE);
-		dup2(fd,STDIN_FILENO);
-		// dup2(get_dupin_fd(cmd), STDIN_FILENO);
+		dup2(fd, STDIN_FILENO);
 	}
 	return (EXIT_SUCCESS);
 }
@@ -57,7 +55,7 @@ int	get_dupin_fd(t_cmd *cmd)
 		{
 			fd = file_open(rdr->file, O_RDONLY, 0);
 			if (fd == -1)
-					return fd;
+				return (fd);
 			close(fd);
 		}
 		last = last->nxt;

--- a/srcs/exec/exec_cmd.c
+++ b/srcs/exec/exec_cmd.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   exec_cmd.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: hnagasak <hnagasak@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*   By: hnagasak <hnagasak@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/31 16:07:17 by hnagasak          #+#    #+#             */
-/*   Updated: 2024/03/22 10:44:30 by hnagasak         ###   ########.fr       */
+/*   Updated: 2024/03/27 16:46:21 by hnagasak         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -67,11 +67,12 @@ int	exec_externalcmd(t_cmd *cmd, t_dlist **env_list)
 	int		exit_status;
 
 	ft_debug("[exec_externalcmd]: %s\n", cmd->argv[0]);
-	env = envlist2arr(env_list);
+	if (cmd->argv[0][0] == '\0')
+		exit(EXIT_SUCCESS);
 	paths = get_paths(env_list);
-	// cmd->path = find_cmd_path(paths, cmd->argv[0]);
 	exit_status = find_cmd_path(&cmd->path, paths, cmd->argv[0]);
 	free_strarr(paths);
+	env = envlist2arr(env_list);
 	if (exit_status != EXIT_SUCCESS)
 		exit(exit_status);
 	if (execve(cmd->path, cmd->argv, env) == -1)
@@ -79,7 +80,7 @@ int	exec_externalcmd(t_cmd *cmd, t_dlist **env_list)
 		perror("ft_execve");
 		exit(EXIT_FAILURE);
 	}
-	return (EXIT_SUCCESS);
+	return (EXIT_FAILURE);
 }
 
 // char	*get_last_redir_file(t_dlist *redir_list)

--- a/srcs/exec/exec_cmd.c
+++ b/srcs/exec/exec_cmd.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   exec_cmd.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: hnagasak <hnagasak@student.42.fr>          +#+  +:+       +#+        */
+/*   By: hnagasak <hnagasak@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/31 16:07:17 by hnagasak          #+#    #+#             */
-/*   Updated: 2024/03/27 16:46:21 by hnagasak         ###   ########.fr       */
+/*   Updated: 2024/03/28 20:18:48 by hnagasak         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,7 +15,7 @@
 #include "free.h"
 #include "utils.h"
 
-// void	exec_builtin(char **argv, t_dlist **env_list)
+// 組み込みコマンド結果をreturnするように修正後、最後のreturnはEXIT_FAILUREにする
 int	exec_builtin(t_cmd *cmd, t_dlist **env_list)
 {
 	ft_debug("[exec_builtin] %s\n", cmd->argv[0]);
@@ -33,7 +33,7 @@ int	exec_builtin(t_cmd *cmd, t_dlist **env_list)
 		return (ft_export(cmd->argv, env_list));
 	else if (ft_strncmp(cmd->argv[0], "unset", 5) == 0)
 		return (ft_unset(cmd->argv, env_list));
-	return (EXIT_SUCCESS); // あとで見直す
+	return (EXIT_SUCCESS);
 }
 
 // return 1 if cmd is a builtin command

--- a/srcs/exec/exec_cmd_list.c
+++ b/srcs/exec/exec_cmd_list.c
@@ -6,7 +6,7 @@
 /*   By: hnagasak <hnagasak@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/07 01:56:44 by hnagasak          #+#    #+#             */
-/*   Updated: 2024/03/27 01:45:27 by hnagasak         ###   ########.fr       */
+/*   Updated: 2024/03/28 09:41:11 by hnagasak         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,13 +23,9 @@ int	exec_single_builtin(t_dlist *current, t_dlist **env_list)
 	set_tmpfile_name(cmd, current->i);
 	store_stdio(current);
 	input_heredocs(cmd, env_list);
-	// dup_stdin(current);
-	if(dup_stdin(current) == EXIT_FAILURE)
+	if (dup_stdin(current) == EXIT_FAILURE)
 		exit(EXIT_FAILURE);
-	// if ((exit_status = dup_stdin(current)) != 0)
-	// 	return (exit_status);
-	// dup_stdout(current);
-	if(dup_stdout(current) == EXIT_FAILURE)
+	if (dup_stdout(current) == EXIT_FAILURE)
 		exit(EXIT_FAILURE);
 	exit_status = exec_builtin(cmd, env_list);
 	delete_tmp_files(cmd);
@@ -42,8 +38,6 @@ void	input_heredocuments(t_dlist **cmd_list, t_dlist **env_list)
 	t_dlist	*current;
 	t_cmd	*cmd;
 
-	// t_dlist	*curdr;
-	// t_redir	*rdr;
 	current = *cmd_list;
 	while (current != NULL)
 	{
@@ -68,7 +62,6 @@ int	exec_external_or_piped_cmd(t_dlist **cmd_list, t_dlist **env_list)
 		cmd = (t_cmd *)current->cont;
 		ft_debug("\n--- exec_cmd[%d]: %s ---\n", current->i, cmd->argv[0]);
 		set_pipe_if_needed(current);
-		// set_tmpfile_name(cmd, current->i);
 		set_fork(current);
 		if (cmd->pid == 0)
 			child_process(current, env_list);

--- a/srcs/exec/exec_cmd_list.c
+++ b/srcs/exec/exec_cmd_list.c
@@ -3,26 +3,24 @@
 /*                                                        :::      ::::::::   */
 /*   exec_cmd_list.c                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: hnagasak <hnagasak@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*   By: hnagasak <hnagasak@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/07 01:56:44 by hnagasak          #+#    #+#             */
-/*   Updated: 2024/03/28 09:41:11 by hnagasak         ###   ########.fr       */
+/*   Updated: 2024/03/30 10:47:18 by hnagasak         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "exec.h"
 
-int	exec_single_builtin(t_dlist *current, t_dlist **env_list)
+int	exec_single_builtin(t_dlist *current, t_dlist **env_list, int exit_status)
 {
 	t_cmd	*cmd;
-	int		exit_status;
 
-	exit_status = 0;
 	cmd = (t_cmd *)current->cont;
 	ft_debug("--- exec_single_builtin %s ---\n", cmd->argv[0]);
 	set_tmpfile_name(cmd, current->i);
 	store_stdio(current);
-	input_heredocs(cmd, env_list);
+	input_heredocs(cmd, env_list, exit_status);
 	if (dup_stdin(current) == EXIT_FAILURE)
 		exit(EXIT_FAILURE);
 	if (dup_stdout(current) == EXIT_FAILURE)
@@ -33,7 +31,8 @@ int	exec_single_builtin(t_dlist *current, t_dlist **env_list)
 	return (exit_status);
 }
 
-void	input_heredocuments(t_dlist **cmd_list, t_dlist **env_list)
+void	input_heredocuments(t_dlist **cmd_list, t_dlist **env_list,
+		int exit_status)
 {
 	t_dlist	*current;
 	t_cmd	*cmd;
@@ -44,19 +43,20 @@ void	input_heredocuments(t_dlist **cmd_list, t_dlist **env_list)
 		cmd = (t_cmd *)current->cont;
 		store_stdio(current);
 		set_tmpfile_name(cmd, current->i);
-		input_heredocs(cmd, env_list);
+		input_heredocs(cmd, env_list, exit_status);
 		restore_stdio(current);
 		current = current->nxt;
 	}
 }
 
-int	exec_external_or_piped_cmd(t_dlist **cmd_list, t_dlist **env_list)
+int	exec_external_or_piped_cmd(t_dlist **cmd_list, t_dlist **env_list,
+		int exit_status)
 {
 	t_dlist	*current;
 	t_cmd	*cmd;
 
 	current = *cmd_list;
-	input_heredocuments(cmd_list, env_list);
+	input_heredocuments(cmd_list, env_list, exit_status);
 	while (current != NULL)
 	{
 		cmd = (t_cmd *)current->cont;
@@ -82,7 +82,8 @@ void	exec_cmd_list(t_dlist **cmd_list, t_dlist **env_list, int *exit_status)
 	if (current == NULL)
 		return ;
 	if (is_builtin_cmd((t_cmd *)current->cont) && current->nxt == NULL)
-		*exit_status = exec_single_builtin(current, env_list);
+		*exit_status = exec_single_builtin(current, env_list, *exit_status);
 	else
-		*exit_status = exec_external_or_piped_cmd(cmd_list, env_list);
+		*exit_status = exec_external_or_piped_cmd(cmd_list, env_list,
+				*exit_status);
 }

--- a/srcs/exec/exec_cmd_list.c
+++ b/srcs/exec/exec_cmd_list.c
@@ -6,7 +6,7 @@
 /*   By: hnagasak <hnagasak@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/07 01:56:44 by hnagasak          #+#    #+#             */
-/*   Updated: 2024/03/24 23:56:25 by hnagasak         ###   ########.fr       */
+/*   Updated: 2024/03/26 22:58:55 by hnagasak         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -31,13 +31,13 @@ int	exec_single_builtin(t_dlist *current, t_dlist **env_list)
 	return (exit_status);
 }
 
-void input_heredocuments(t_dlist **cmd_list, t_dlist **env_list)
+void	input_heredocuments(t_dlist **cmd_list, t_dlist **env_list)
 {
 	t_dlist	*current;
-	// t_dlist	*curdr;
 	t_cmd	*cmd;
-	// t_redir	*rdr;
 
+	// t_dlist	*curdr;
+	// t_redir	*rdr;
 	current = *cmd_list;
 	while (current != NULL)
 	{
@@ -56,7 +56,6 @@ int	exec_external_or_piped_cmd(t_dlist **cmd_list, t_dlist **env_list)
 	t_cmd	*cmd;
 
 	current = *cmd_list;
-
 	input_heredocuments(cmd_list, env_list);
 	while (current != NULL)
 	{

--- a/srcs/exec/exec_cmd_list.c
+++ b/srcs/exec/exec_cmd_list.c
@@ -6,7 +6,7 @@
 /*   By: hnagasak <hnagasak@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/07 01:56:44 by hnagasak          #+#    #+#             */
-/*   Updated: 2024/03/26 22:58:55 by hnagasak         ###   ########.fr       */
+/*   Updated: 2024/03/27 01:45:27 by hnagasak         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,8 +23,14 @@ int	exec_single_builtin(t_dlist *current, t_dlist **env_list)
 	set_tmpfile_name(cmd, current->i);
 	store_stdio(current);
 	input_heredocs(cmd, env_list);
-	dup_stdin(current);
-	dup_stdout(current);
+	// dup_stdin(current);
+	if(dup_stdin(current) == EXIT_FAILURE)
+		exit(EXIT_FAILURE);
+	// if ((exit_status = dup_stdin(current)) != 0)
+	// 	return (exit_status);
+	// dup_stdout(current);
+	if(dup_stdout(current) == EXIT_FAILURE)
+		exit(EXIT_FAILURE);
 	exit_status = exec_builtin(cmd, env_list);
 	delete_tmp_files(cmd);
 	restore_stdio(current);

--- a/srcs/exec/find_cmd_path.c
+++ b/srcs/exec/find_cmd_path.c
@@ -6,7 +6,7 @@
 /*   By: hnagasak <hnagasak@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/06 22:02:46 by hnagasak          #+#    #+#             */
-/*   Updated: 2024/03/22 19:37:23 by hnagasak         ###   ########.fr       */
+/*   Updated: 2024/03/28 09:32:32 by hnagasak         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -41,66 +41,50 @@ char	**get_paths(t_dlist **env_list)
 	return (paths);
 }
 
-// 外部コマンドのパスを探し、コマンド名を連結して返す
-// paths: PATHを:で分割した文字列配列
-// cmd: 検索するコマンド名
-// char	*_find_cmd_path(char *paths[], char *cmd)
+// int	errmsg_isdir(char *cmd)
 // {
-// 	int		i;
-// 	char	*cmd_path;
+// 	ft_errmsg("minishell: ");
+// 	ft_errmsg(cmd);
+// 	ft_errmsg(": is a directory\n");
+// 	return (STATUS_EISDIR);
+// }
 
-// 	if (ft_strchr(cmd, '/') != NULL || paths == NULL)
-// 	{
-// 		if (access(cmd, X_OK) == 0)
-// 			return (ft_strdup(cmd));
-// 		printf("%s: No such file or directory\n", cmd);
-// 		return (NULL);
-// 	}
-// 	i = 0;
-// 	while (paths[i] != NULL)
-// 	{
-// 		cmd_path = cat_path(paths[i], cmd);
-// 		if (access(cmd_path, X_OK) == 0)
-// 		{
-// 			return (cmd_path);
-// 		}
-// 		free(cmd_path);
-// 		i++;
-// 	}
+// int	errmsg_missing_path(char *cmd)
+// {
+// 	ft_errmsg("minishell: ");
+// 	ft_errmsg(cmd);
+// 	ft_errmsg(": No such file or directory\n");
+// 	return (STATUS_ENOENT);
+// }
+
+// int	errmsg_permission(char *cmd)
+// {
+// 	ft_errmsg("minishell: ");
+// 	ft_errmsg(cmd);
+// 	ft_errmsg(": Permission denied\n");
+// 	return (STATUS_EACCES);
+// }
+
+// int	errmsg_cmd_not_found(char *cmd)
+// {
 // 	ft_errmsg("minishell: ");
 // 	ft_errmsg(cmd);
 // 	ft_errmsg(": command not found\n");
-// 	return (NULL);
+// 	return (STATUS_CMD_NOT_FOUND);
 // }
 
 int	find_cmd_path(char **cmd_path, char *paths[], char *cmd)
 {
 	int	i;
 
-	// char	*cmd_path;
 	if (ft_strchr(cmd, '/') != NULL || paths == NULL)
 	{
 		if (is_directory(cmd))
-		{
-			ft_errmsg("minishell: ");
-			ft_errmsg(cmd);
-			ft_errmsg(": is a directory\n");
-			return (STATUS_EISDIR);
-		}
+			return (errmsg_isdir(cmd));
 		if (access(cmd, F_OK) != 0)
-		{
-			ft_errmsg("minishell: ");
-			ft_errmsg(cmd);
-			ft_errmsg(": No such file or directory\n");
-			return (STATUS_ENOENT);
-		}
+			return (errmsg_missing_path(cmd));
 		if (access(cmd, X_OK) != 0)
-		{
-			ft_errmsg("minishell: ");
-			ft_errmsg(cmd);
-			ft_errmsg(": Permission denied\n");
-			return (STATUS_EACCES);
-		}
+			return (errmsg_permission(cmd));
 		*cmd_path = ft_strdup(cmd);
 		return (EXIT_SUCCESS);
 	}
@@ -113,8 +97,5 @@ int	find_cmd_path(char **cmd_path, char *paths[], char *cmd)
 		*cmd_path = ft_free(*cmd_path);
 		i++;
 	}
-	ft_errmsg("minishell: ");
-	ft_errmsg(cmd);
-	ft_errmsg(": command not found\n");
-	return (STATUS_CMD_NOT_FOUND);
+	return (errmsg_cmd_not_found(cmd));
 }

--- a/srcs/exec/find_cmd_path_errmsg.c
+++ b/srcs/exec/find_cmd_path_errmsg.c
@@ -1,0 +1,46 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   find_cmd_path_errmsg.c                             :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: hnagasak <hnagasak@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/03/06 22:02:46 by hnagasak          #+#    #+#             */
+/*   Updated: 2024/03/28 09:36:18 by hnagasak         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "exec.h"
+#include "exit_status.h"
+
+int	errmsg_isdir(char *cmd)
+{
+	ft_errmsg("minishell: ");
+	ft_errmsg(cmd);
+	ft_errmsg(": is a directory\n");
+	return (STATUS_EISDIR);
+}
+
+int	errmsg_missing_path(char *cmd)
+{
+	ft_errmsg("minishell: ");
+	ft_errmsg(cmd);
+	ft_errmsg(": No such file or directory\n");
+	return (STATUS_ENOENT);
+}
+
+int	errmsg_permission(char *cmd)
+{
+	ft_errmsg("minishell: ");
+	ft_errmsg(cmd);
+	ft_errmsg(": Permission denied\n");
+	return (STATUS_EACCES);
+}
+
+int	errmsg_cmd_not_found(char *cmd)
+{
+	ft_errmsg("minishell: ");
+	ft_errmsg(cmd);
+	ft_errmsg(": command not found\n");
+	return (STATUS_CMD_NOT_FOUND);
+}

--- a/srcs/exec/forked_process_helper.c
+++ b/srcs/exec/forked_process_helper.c
@@ -6,7 +6,7 @@
 /*   By: hnagasak <hnagasak@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/07 02:21:39 by hnagasak          #+#    #+#             */
-/*   Updated: 2024/03/24 23:57:43 by hnagasak         ###   ########.fr       */
+/*   Updated: 2024/03/27 02:45:02 by hnagasak         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,13 +34,22 @@ void	close_parent_pipe(t_dlist *current)
 void	child_process(t_dlist *current, t_dlist **env_list)
 {
 	t_cmd	*cmd;
+	// int result1;
+	// int result2;
 
 	cmd = (t_cmd *)current->cont;
 	ft_debug("[child process] close pipin fd:%d\n", cmd->pipe[0]);
 	cmd->pipe[0] = ft_close(cmd->pipe[0]);
 	store_stdio(current);
-	dup_stdin(current);
-	dup_stdout(current);
+	// result1 = dup_stdin(current);
+	// result2 = dup_stdout(current);
+	// if(result1 == EXIT_FAILURE || result2 == EXIT_FAILURE)
+	// 	exit(EXIT_FAILURE);
+	if(dup_stdin(current) == EXIT_FAILURE)
+		exit(EXIT_FAILURE);
+	if(dup_stdout(current) == EXIT_FAILURE)
+		exit(EXIT_FAILURE);
+	// dup_stdout(current);
 	exec_cmd(cmd, env_list);
 }
 

--- a/srcs/exec/forked_process_helper.c
+++ b/srcs/exec/forked_process_helper.c
@@ -6,7 +6,7 @@
 /*   By: hnagasak <hnagasak@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/07 02:21:39 by hnagasak          #+#    #+#             */
-/*   Updated: 2024/03/27 02:45:02 by hnagasak         ###   ########.fr       */
+/*   Updated: 2024/03/28 09:39:21 by hnagasak         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,22 +34,15 @@ void	close_parent_pipe(t_dlist *current)
 void	child_process(t_dlist *current, t_dlist **env_list)
 {
 	t_cmd	*cmd;
-	// int result1;
-	// int result2;
 
 	cmd = (t_cmd *)current->cont;
 	ft_debug("[child process] close pipin fd:%d\n", cmd->pipe[0]);
 	cmd->pipe[0] = ft_close(cmd->pipe[0]);
 	store_stdio(current);
-	// result1 = dup_stdin(current);
-	// result2 = dup_stdout(current);
-	// if(result1 == EXIT_FAILURE || result2 == EXIT_FAILURE)
-	// 	exit(EXIT_FAILURE);
-	if(dup_stdin(current) == EXIT_FAILURE)
+	if (dup_stdin(current) == EXIT_FAILURE)
 		exit(EXIT_FAILURE);
-	if(dup_stdout(current) == EXIT_FAILURE)
+	if (dup_stdout(current) == EXIT_FAILURE)
 		exit(EXIT_FAILURE);
-	// dup_stdout(current);
 	exec_cmd(cmd, env_list);
 }
 

--- a/srcs/exec/heredoc.c
+++ b/srcs/exec/heredoc.c
@@ -6,7 +6,7 @@
 /*   By: hnagasak <hnagasak@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/07 02:00:02 by hnagasak          #+#    #+#             */
-/*   Updated: 2024/03/26 22:57:44 by hnagasak         ###   ########.fr       */
+/*   Updated: 2024/03/28 20:50:33 by hnagasak         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -65,25 +65,10 @@ char	*expand_heredoc(char *str, t_dlist **env_list)
 	return (str_head);
 }
 
-void	sig_hd(int signum)
-{
-	(void)signum;
-	g_signum = SIGINT;
-	ft_putstr_fd("\n", STDOUT_FILENO);
-	close(STDIN_FILENO);
-}
-
-int	eof_handler(void)
-{
-	write(STDOUT_FILENO, "\033[A\033[2K\r> ", 10);
-	return (1);
-}
-
 void	input_hd(t_cmd *cmd, t_redir *redir, t_dlist **env_list)
 {
 	char	*line;
 	int		delimitype;
-	char	*delim;
 	int		fd;
 
 	fd = file_open(redir->file, O_WRONLY | O_CREAT | O_TRUNC,
@@ -97,17 +82,7 @@ void	input_hd(t_cmd *cmd, t_redir *redir, t_dlist **env_list)
 		line = ft_free(line);
 		dup2(cmd->stdio[0], STDIN_FILENO);
 		line = readline("> ");
-		if (g_signum == SIGINT)
-		{
-			close(fd);
-			fd = file_open(redir->file, O_WRONLY | O_CREAT | O_TRUNC,
-					S_IRUSR | S_IWUSR);
-			break ;
-		}
-		if (line == NULL && eof_handler())
-			break ;
-		delim = ft_strtrim(redir->delimiter, "\"\'");
-		if (ft_strncmp(line, delim, ft_strlen(delim) + 1) == 0)
+		if (should_break(line, redir, &fd))
 			break ;
 		if (delimitype == NOT_IN_QUOTE)
 			line = expand_heredoc(line, env_list);

--- a/srcs/exec/heredoc_signal.c
+++ b/srcs/exec/heredoc_signal.c
@@ -6,14 +6,13 @@
 /*   By: hnagasak <hnagasak@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/07 02:00:02 by hnagasak          #+#    #+#             */
-/*   Updated: 2024/03/28 20:50:20 by hnagasak         ###   ########.fr       */
+/*   Updated: 2024/03/30 05:50:51 by hnagasak         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "exec.h"
 
-// #include "expander.h"
-// #include "free.h"
+int		g_signum = 0;
 
 void	sig_hd(int signum)
 {

--- a/srcs/exec/heredoc_signal.c
+++ b/srcs/exec/heredoc_signal.c
@@ -1,0 +1,49 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   heredoc_signal.c                                   :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: hnagasak <hnagasak@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/03/07 02:00:02 by hnagasak          #+#    #+#             */
+/*   Updated: 2024/03/28 20:50:20 by hnagasak         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "exec.h"
+
+// #include "expander.h"
+// #include "free.h"
+
+void	sig_hd(int signum)
+{
+	(void)signum;
+	g_signum = SIGINT;
+	ft_putstr_fd("\n", STDOUT_FILENO);
+	close(STDIN_FILENO);
+}
+
+int	eof_handler(void)
+{
+	write(STDOUT_FILENO, "\033[A\033[2K\r> ", 10);
+	return (1);
+}
+
+int	should_break(char *line, t_redir *redir, int *fd)
+{
+	char	*delim;
+
+	if (g_signum == SIGINT)
+	{
+		close(*fd);
+		*fd = file_open(redir->file, O_WRONLY | O_CREAT | O_TRUNC,
+				S_IRUSR | S_IWUSR);
+		return (1);
+	}
+	if (line == NULL && eof_handler())
+		return (1);
+	delim = ft_strtrim(redir->delimiter, "\"\'");
+	if (ft_strncmp(line, delim, ft_strlen(delim) + 1) == 0)
+		return (1);
+	return (0);
+}

--- a/srcs/exec/utils.c
+++ b/srcs/exec/utils.c
@@ -6,7 +6,7 @@
 /*   By: hnagasak <hnagasak@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/07 02:13:48 by hnagasak          #+#    #+#             */
-/*   Updated: 2024/03/07 02:25:13 by hnagasak         ###   ########.fr       */
+/*   Updated: 2024/03/27 01:27:25 by hnagasak         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -66,7 +66,8 @@ int	file_open(char *file, int flag, int mode)
 		ft_errmsg(file);
 		ft_errmsg(": ");
 		ft_errmsg(strerror(errno));
-		exit(EXIT_FAILURE);
+		ft_errmsg("\n");
+		// exit(EXIT_FAILURE);
 	}
 	return (fd);
 }

--- a/srcs/exec/utils.c
+++ b/srcs/exec/utils.c
@@ -6,7 +6,7 @@
 /*   By: hnagasak <hnagasak@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/07 02:13:48 by hnagasak          #+#    #+#             */
-/*   Updated: 2024/03/27 01:27:25 by hnagasak         ###   ########.fr       */
+/*   Updated: 2024/03/28 20:50:51 by hnagasak         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -67,7 +67,6 @@ int	file_open(char *file, int flag, int mode)
 		ft_errmsg(": ");
 		ft_errmsg(strerror(errno));
 		ft_errmsg("\n");
-		// exit(EXIT_FAILURE);
 	}
 	return (fd);
 }

--- a/srcs/expander/replace.c
+++ b/srcs/expander/replace.c
@@ -1,0 +1,85 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   replace.c                                          :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: hnagasak <hnagasak@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/03/16 17:52:02 by hnagasak          #+#    #+#             */
+/*   Updated: 2024/03/28 08:52:21 by hnagasak         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "expander.h"
+
+static void	copy_str_func(char **new_str, char **src, char end)
+{
+	while (**src != end)
+	{
+		**new_str = **src;
+		(*new_str)++;
+		(*src)++;
+	}
+}
+
+/**
+ * @brief Expands the first environment variable in a string with env_value.
+ * @param str The input string to be replaced.
+ * @param env_value The value to replace the environment variable with.
+ * @return A new string with the first environment variable replaced.
+ */
+void	replace_env_value(char **str_head, char **start, char *env_value)
+{
+	char	*new_str;
+	char	*new_str_head;
+	char	*str;
+
+	new_str = ft_malloc(sizeof(char) * (ft_strlen(*str_head)
+				+ ft_strlen(env_value) + 1));
+	str = *str_head;
+	new_str_head = new_str;
+	while (str != *start)
+	{
+		*new_str = *str;
+		new_str++;
+		str++;
+	}
+	copy_str_func(&new_str, &env_value, '\0');
+	str++;
+	while (is_env_key_char(*str) || *str == '?')
+		str++;
+	*start = new_str - 1;
+	copy_str_func(&new_str, &str, '\0');
+	*new_str = '\0';
+	free(*str_head);
+	*str_head = new_str_head;
+}
+
+void	replace_exit_status(char **str_head, char **start, int exit_status)
+{
+	char	*new_str;
+	char	*new_str_head;
+	char	*str;
+	char	*str_exit_status;
+
+	str_exit_status = ft_itoa(exit_status);
+	new_str = ft_malloc(sizeof(char) * (ft_strlen(*str_head)
+				+ ft_strlen(str_exit_status) + 1));
+	str = *str_head;
+	new_str_head = new_str;
+	while (str != *start)
+	{
+		*new_str = *str;
+		new_str++;
+		str++;
+	}
+	copy_str_func(&new_str, &str_exit_status, '\0');
+	str++;
+	while (*str == '?')
+		str++;
+	*start = new_str - 1;
+	copy_str_func(&new_str, &str, '\0');
+	*new_str = '\0';
+	free(*str_head);
+	*str_head = new_str_head;
+}

--- a/srcs/expander/replace_env.c
+++ b/srcs/expander/replace_env.c
@@ -6,7 +6,7 @@
 /*   By: hnagasak <hnagasak@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/16 17:52:02 by hnagasak          #+#    #+#             */
-/*   Updated: 2024/03/22 10:34:36 by hnagasak         ###   ########.fr       */
+/*   Updated: 2024/03/28 08:52:59 by hnagasak         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -44,79 +44,7 @@ char	*find_env_value(char *char_position, t_dlist *env_list)
 	return (NULL);
 }
 
-void	copy_str_func(char **new_str, char **src, char end)
-{
-	while (**src != end)
-	{
-		**new_str = **src;
-		(*new_str)++;
-		(*src)++;
-	}
-}
-
-/**
- * @brief Expands the first environment variable in a string with env_value.
- * @param str The input string to be replaced.
- * @param env_value The value to replace the environment variable with.
- * @return A new string with the first environment variable replaced.
- */
-void	replace_env_value(char **str_head, char **start, char *env_value)
-{
-	char	*new_str;
-	char	*new_str_head;
-	char	*str;
-
-	new_str = ft_malloc(sizeof(char) * (ft_strlen(*str_head)
-				+ ft_strlen(env_value) + 1));
-	str = *str_head;
-	new_str_head = new_str;
-	while (str != *start)
-	{
-		*new_str = *str;
-		new_str++;
-		str++;
-	}
-	copy_str_func(&new_str, &env_value, '\0');
-	str++;
-	while (is_env_key_char(*str) || *str == '?')
-		str++;
-	*start = new_str - 1;
-	copy_str_func(&new_str, &str, '\0');
-	*new_str = '\0';
-	free(*str_head);
-	*str_head = new_str_head;
-}
-
-void	replace_exit_status(char **str_head, char **start, int exit_status)
-{
-	char	*new_str;
-	char	*new_str_head;
-	char	*str;
-	char	*str_exit_status;
-
-	str_exit_status = ft_itoa(exit_status);
-	new_str = ft_malloc(sizeof(char) * (ft_strlen(*str_head)
-				+ ft_strlen(str_exit_status) + 1));
-	str = *str_head;
-	new_str_head = new_str;
-	while (str != *start)
-	{
-		*new_str = *str;
-		new_str++;
-		str++;
-	}
-	copy_str_func(&new_str, &str_exit_status, '\0');
-	str++;
-	while (*str == '?')
-		str++;
-	*start = new_str - 1;
-	copy_str_func(&new_str, &str, '\0');
-	*new_str = '\0';
-	free(*str_head);
-	*str_head = new_str_head;
-}
-
-size_t	toggle_quote_state(size_t state, char *str)
+static size_t	toggle_quote_state(size_t state, char *str)
 {
 	if (*str == '\'' && state == NOT_IN_QUOTE)
 		return (IN_QUOTE);

--- a/srcs/lexer/validate_token2.c
+++ b/srcs/lexer/validate_token2.c
@@ -3,14 +3,15 @@
 /*                                                        :::      ::::::::   */
 /*   validate_token2.c                                  :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: kogitsu <kogitsu@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*   By: hnagasak <hnagasak@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/28 22:21:27 by kogitsu           #+#    #+#             */
-/*   Updated: 2024/02/28 22:22:09 by kogitsu          ###   ########.fr       */
+/*   Updated: 2024/03/28 20:57:00 by hnagasak         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "lexer.h"
+#include "utils.h"
 
 int	is_arguments(t_token *tkn_list)
 {
@@ -66,5 +67,8 @@ int	is_cmd_line(t_token *tkn_list)
 	if (is_piped_commands(tkn_list))
 		return (1);
 	else
+	{
+		ft_errmsg("minishell: syntax error\n");
 		return (0);
+	}
 }

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   main.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: hnagasak <hnagasak@student.42.fr>          +#+  +:+       +#+        */
+/*   By: hnagasak <hnagasak@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/26 14:40:15 by hnagasak          #+#    #+#             */
-/*   Updated: 2024/03/27 16:05:20 by hnagasak         ###   ########.fr       */
+/*   Updated: 2024/03/28 20:54:45 by hnagasak         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -53,10 +53,7 @@ void	mainloop(char *line, t_dlist **env_list)
 		tokens = tokenize(line);
 		free(line);
 		if (!is_cmd_line(tokens))
-		{
-			ft_errmsg("syntax error\n");
 			continue ;
-		}
 		tokens = expand_env(tokens, env_list, exit_status);
 		cmd_list = create_cmd_list(tokens, env_list);
 		print_cmd_list(cmd_list);

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -6,7 +6,7 @@
 /*   By: hnagasak <hnagasak@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/26 14:40:15 by hnagasak          #+#    #+#             */
-/*   Updated: 2024/03/17 20:28:37 by hnagasak         ###   ########.fr       */
+/*   Updated: 2024/03/27 16:05:20 by hnagasak         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -59,7 +59,7 @@ void	mainloop(char *line, t_dlist **env_list)
 		}
 		tokens = expand_env(tokens, env_list, exit_status);
 		cmd_list = create_cmd_list(tokens, env_list);
-		// print_cmd_list(cmd_list);
+		print_cmd_list(cmd_list);
 		exec_cmd_list(cmd_list, env_list, &exit_status);
 		free_tokens(tokens);
 		free_cmd_list(cmd_list);

--- a/srcs/parser/parser.c
+++ b/srcs/parser/parser.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   parser.c                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: hnagasak <hnagasak@student.42.fr>          +#+  +:+       +#+        */
+/*   By: hnagasak <hnagasak@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/01/13 14:20:30 by kogitsu           #+#    #+#             */
-/*   Updated: 2024/03/27 16:48:29 by hnagasak         ###   ########.fr       */
+/*   Updated: 2024/03/28 09:13:56 by hnagasak         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -45,11 +45,8 @@ void	create_cmd(t_token **tokens, t_cmd *cmd, size_t *i)
 		process_redir(tokens, cmd, REDIR_HEREDOC);
 	if ((*tokens)->next == NULL || (*tokens)->next->type == CHAR_PIPE)
 	{
-		if (cmd->argv[0] == NULL)
-		{
-			cmd->argv[0] = ft_strdup("");
-			*i = 1;
-		}
+		if (*i == 0 && cmd->argv[*i] == NULL)
+			cmd->argv[(*i)++] = ft_strdup("");
 		cmd->argv[*i] = NULL;
 	}
 }

--- a/srcs/parser/parser.c
+++ b/srcs/parser/parser.c
@@ -6,7 +6,7 @@
 /*   By: hnagasak <hnagasak@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/01/13 14:20:30 by kogitsu           #+#    #+#             */
-/*   Updated: 2024/03/17 20:46:42 by hnagasak         ###   ########.fr       */
+/*   Updated: 2024/03/27 16:48:29 by hnagasak         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -44,7 +44,14 @@ void	create_cmd(t_token **tokens, t_cmd *cmd, size_t *i)
 	else if (token->type == D_LESSER)
 		process_redir(tokens, cmd, REDIR_HEREDOC);
 	if ((*tokens)->next == NULL || (*tokens)->next->type == CHAR_PIPE)
+	{
+		if (cmd->argv[0] == NULL)
+		{
+			cmd->argv[0] = ft_strdup("");
+			*i = 1;
+		}
 		cmd->argv[*i] = NULL;
+	}
 }
 
 t_dlist	**create_cmd_list(t_token *tokens, t_dlist **env_list)

--- a/srcs/utils/envp.c
+++ b/srcs/utils/envp.c
@@ -6,7 +6,7 @@
 /*   By: hnagasak <hnagasak@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/27 01:45:42 by hnagasak          #+#    #+#             */
-/*   Updated: 2024/03/20 22:09:19 by hnagasak         ###   ########.fr       */
+/*   Updated: 2024/03/28 09:18:07 by hnagasak         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -69,39 +69,4 @@ size_t	get_argc(char *argv[])
 int	is_env_key_char(char c)
 {
 	return (ft_isalnum(c) || c == '_');
-}
-
-#include <sys/stat.h>
-
-int	is_executable_file(char *path)
-{
-	struct stat	buf;
-
-	if (stat(path, &buf) == -1)
-		return (0);
-	if (S_ISREG(buf.st_mode) && (buf.st_mode & S_IXUSR))
-		return (1);
-	return (0);
-}
-
-int is_updatable_file(char *path)
-{
-	struct stat	buf;
-
-	if (stat(path, &buf) == -1)
-		return (0);
-	if (S_ISREG(buf.st_mode) && (buf.st_mode & S_IWUSR))
-		return (1);
-	return (0);
-}
-
-int	is_directory(const char *path)
-{
-	struct stat	statbuf;
-
-	if (stat(path, &statbuf) != 0)
-	{
-		return (0); // エラーがあれば、ディレクトリではないと仮定
-	}
-	return (S_ISDIR(statbuf.st_mode));
 }

--- a/srcs/utils/path_validator.c
+++ b/srcs/utils/path_validator.c
@@ -6,35 +6,13 @@
 /*   By: hnagasak <hnagasak@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/27 01:45:42 by hnagasak          #+#    #+#             */
-/*   Updated: 2024/03/28 09:17:52 by hnagasak         ###   ########.fr       */
+/*   Updated: 2024/03/28 21:03:59 by hnagasak         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "debug.h"
 #include "utils.h"
 #include <sys/stat.h>
-
-int	is_executable_file(char *path)
-{
-	struct stat	buf;
-
-	if (stat(path, &buf) == -1)
-		return (0);
-	if (S_ISREG(buf.st_mode) && (buf.st_mode & S_IXUSR))
-		return (1);
-	return (0);
-}
-
-int	is_updatable_file(char *path)
-{
-	struct stat	buf;
-
-	if (stat(path, &buf) == -1)
-		return (0);
-	if (S_ISREG(buf.st_mode) && (buf.st_mode & S_IWUSR))
-		return (1);
-	return (0);
-}
 
 int	is_directory(const char *path)
 {

--- a/srcs/utils/path_validator.c
+++ b/srcs/utils/path_validator.c
@@ -1,0 +1,46 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   path_validator.c                                   :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: hnagasak <hnagasak@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/12/27 01:45:42 by hnagasak          #+#    #+#             */
+/*   Updated: 2024/03/28 09:17:52 by hnagasak         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "debug.h"
+#include "utils.h"
+#include <sys/stat.h>
+
+int	is_executable_file(char *path)
+{
+	struct stat	buf;
+
+	if (stat(path, &buf) == -1)
+		return (0);
+	if (S_ISREG(buf.st_mode) && (buf.st_mode & S_IXUSR))
+		return (1);
+	return (0);
+}
+
+int	is_updatable_file(char *path)
+{
+	struct stat	buf;
+
+	if (stat(path, &buf) == -1)
+		return (0);
+	if (S_ISREG(buf.st_mode) && (buf.st_mode & S_IWUSR))
+		return (1);
+	return (0);
+}
+
+int	is_directory(const char *path)
+{
+	struct stat	statbuf;
+
+	if (stat(path, &statbuf) != 0)
+		return (0);
+	return (S_ISDIR(statbuf.st_mode));
+}


### PR DESCRIPTION
[minishell_tester](https://github.com/LucasKuhn/minishell_tester)の対応および、その他のバグ修正完了
### 修正後のテスト結果
```sh
# NG3件
Test  83: ❌ echo hi >         ./outfiles/outfile01 bye 
Test 105: ❌ cat >./outfiles/outfile01 <missing 
Test 108: ❌ cat >./outfiles/outfile01 <missing >./test_files/invalid_permission 
# 警告2件
Test 107: ✅⚠️  cat >./test_files/invalid_permission <missing 
mini error = ( No such file or directory)
bash error = ( Permission denied)
Test 120: ✅⚠️  ls >>./test_files/invalid_permission >>./outfiles/outfile02 <missing 
mini error = ( No such file or directory)
bash error = ( Permission denied)

143/146
```

以下は一旦対応しない方針
- Test  83: ❌ echo hi >         ./outfiles/outfile01 bye
  - 個別に実行すると差分なさそう
- Test 105: ❌ cat >./outfiles/outfile01 <missing 
  - bashだとoutfile01が作成されるがminishellだとされない
  - minishellは入力リダイレクトから先に処理してるので、outfile01が作成される前に`No such file or directory`になる
- Test 108: ❌ cat >./outfiles/outfile01 <missing >./test_files/invalid_permission
  - bashだとoutfile01が作成されるがminishellだとされない
  - minishellは入力リダイレクトから先に処理してるので、outfile01が作成される前に`No such file or directory`になる


