### PR TITLE
メモリリークの修正など

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ PARSER_FILES := parser.c parser_utils.c
 PARSER_SRCS := $(addprefix $(PARSER_DIR)/, $(PARSER_FILES))
 
 UTILS_DIR := srcs/utils
-UTILS_FILES := envp.c free.c free2.c list.c malloc.c t_env.c path_validator.c
+UTILS_FILES := envp.c free.c free2.c list.c malloc.c path_validator.c signal_handler_in_input.c t_env.c 
 UTILS_SRCS := $(addprefix $(UTILS_DIR)/, $(UTILS_FILES))
 
 CC		:= cc

--- a/includes/signal_handlers.h
+++ b/includes/signal_handlers.h
@@ -6,7 +6,7 @@
 /*   By: hnagasak <hnagasak@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/04 04:11:28 by hnagasak          #+#    #+#             */
-/*   Updated: 2024/04/04 05:34:05 by hnagasak         ###   ########.fr       */
+/*   Updated: 2024/04/07 23:18:40 by hnagasak         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,14 +15,12 @@
 
 extern int	g_signum;
 
-// main.c
-// void		sigint_handler_in_input(int signum);
-// void	sigquit_handler_in_input(int signum);
-
-// heredoc_signal.c
+// srcs/utils/signal_handler_in_input.c
+void		sigint_handler_in_input(int signum);
+int			eof_handler_in_input(char *line);
+// srcs/exec/signal_handlers.c
 void		sigint_handler_in_heredoc(int signum);
 int			eof_handler_in_heredoc(void);
-// void	sigquit_handler_in_heredoc(int signum);
 void		sigint_handler_in_exec(int signum);
 void		sigquit_handler_in_exec(int signum);
 

--- a/srcs/expander/expander.c
+++ b/srcs/expander/expander.c
@@ -6,7 +6,7 @@
 /*   By: hnagasak <hnagasak@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/01/27 15:27:21 by kogitsu           #+#    #+#             */
-/*   Updated: 2024/04/07 14:05:29 by hnagasak         ###   ########.fr       */
+/*   Updated: 2024/04/07 23:03:22 by hnagasak         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -105,6 +105,8 @@ static void	handle_expanded_tokens(t_token **expanded_tokens, t_token **current,
 			(*current)->prev->next = (*current)->next;
 		if ((*current)->next != NULL)
 			(*current)->next->prev = (*current)->prev;
+		free((*current)->str);
+		free(*current);
 	}
 }
 

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -6,7 +6,7 @@
 /*   By: hnagasak <hnagasak@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/26 14:40:15 by hnagasak          #+#    #+#             */
-/*   Updated: 2024/04/04 04:56:11 by hnagasak         ###   ########.fr       */
+/*   Updated: 2024/04/07 23:24:02 by hnagasak         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,27 +17,18 @@
 #include "free.h"
 #include "lexer.h"
 #include "parser.h"
+#include "signal_handlers.h"
 #include "utils.h"
 #include <errno.h>
 #include <signal.h>
 #include <stdio.h>
 
-int		g_signum = 0;
+int			g_signum = 0;
 
-void	sigint_handler_in_input(int signum)
+static void	set_signal_handler(void)
 {
-	(void)signum;
-	ft_putstr_fd("\n", STDOUT_FILENO);
-	rl_on_new_line();
-	rl_replace_line("", 0);
-	rl_redisplay();
-}
-
-int	eof_handler_in_input(char *line)
-{
-	free(line);
-	printf("\033[A\033[2K\rminishell > exit\n");
-	return (1);
+	signal(SIGINT, sigint_handler_in_input);
+	signal(SIGQUIT, SIG_IGN);
 }
 
 int	newline_process(char *line)
@@ -55,7 +46,7 @@ void	mainloop(char *line, t_dlist **env_list)
 	exit_status = 0;
 	while (1)
 	{
-		signal(SIGINT, sigint_handler_in_input);
+		set_signal_handler();
 		line = readline("minishell > ");
 		if (line == NULL && eof_handler_in_input(line))
 			break ;
@@ -82,7 +73,6 @@ int	main(int argc, char **argv, char **envp)
 
 	(void)argc;
 	(void)argv;
-	signal(SIGQUIT, SIG_IGN);
 	line = NULL;
 	env_list = init_env(envp);
 	mainloop(line, env_list);

--- a/srcs/utils/signal_handler_in_input.c
+++ b/srcs/utils/signal_handler_in_input.c
@@ -1,0 +1,34 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   signal_handler_in_input.c                          :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: hnagasak <hnagasak@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/03/02 12:15:09 by kogitsu           #+#    #+#             */
+/*   Updated: 2024/04/07 23:22:22 by hnagasak         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "signal_handlers.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+// Error if included before stdio.h
+#include <readline/readline.h>
+
+void	sigint_handler_in_input(int signum)
+{
+	(void)signum;
+	write(STDOUT_FILENO, "\n", 1);
+	rl_on_new_line();
+	rl_replace_line("", 0);
+	rl_redisplay();
+}
+
+int	eof_handler_in_input(char *line)
+{
+	free(line);
+	printf("\033[A\033[2K\rminishell > exit\n");
+	return (1);
+}


### PR DESCRIPTION
下記2点の修正
### 存在しない変数の展開でメモリリーク
```sh
minishell > echo $UNKNOWN # ここでメモリリーク

minishell >
```

### SIGQUIT(Ctrl + \\)のシグナルハンドラ復元
```sh
minishell > cat
^\Quit: 3 # ここまで正しい（コマンド実行中にSIGQUITするとコマンド入力に戻る）
Quit: 3ll > # コマンド入力中にSIGQUITしても、コマンド実行中のシグナルハンドラのまま
```