### PR TITLE
Heredocのメモリリーク修正

### DIFF
--- a/srcs/exec/heredoc.c
+++ b/srcs/exec/heredoc.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   heredoc.c                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: hnagasak <hnagasak@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*   By: hnagasak <hnagasak@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/07 02:00:02 by hnagasak          #+#    #+#             */
-/*   Updated: 2024/04/05 06:24:23 by hnagasak         ###   ########.fr       */
+/*   Updated: 2024/05/11 15:45:43 by hnagasak         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -68,7 +68,11 @@ int	should_break(char *line, t_redir *redir, int *fd)
 		return (1);
 	delim = ft_strtrim(redir->delimiter, "\"\'");
 	if (ft_strncmp(line, delim, ft_strlen(delim) + 1) == 0)
+	{
+		ft_free(delim);
 		return (1);
+	}
+	ft_free(delim);
 	return (0);
 }
 

--- a/srcs/utils/free.c
+++ b/srcs/utils/free.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   free.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: hnagasak <hnagasak@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*   By: hnagasak <hnagasak@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/28 21:53:13 by kogitsu           #+#    #+#             */
-/*   Updated: 2024/03/11 10:16:36 by hnagasak         ###   ########.fr       */
+/*   Updated: 2024/05/11 17:15:28 by hnagasak         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -38,6 +38,8 @@ void	free_redir(t_dlist *redir_list)
 		redir = (t_redir *)redir_list->cont;
 		free(redir->file);
 		redir->file = NULL;
+		free(redir->delimiter);
+		redir->delimiter = NULL;
 		free(redir);
 		redir_list->cont = NULL;
 		redir_list = redir_list->nxt;


### PR DESCRIPTION
### リークが起きるコマンド
```sh
minishell > cat << EOF
> 111111
> 22222
> EOF
minishell > exit
```
### 原因
redir->delimiter関連のfreeができてない